### PR TITLE
add poweroff

### DIFF
--- a/pyhifiberry/audiocontrol2.py
+++ b/pyhifiberry/audiocontrol2.py
@@ -107,3 +107,6 @@ class Audiocontrol2:
 
         r = await self._request("POST", API_VOLUME, json={"percent": str(vol)})
         return r
+
+    async def poweroff(self):
+        await self._request("POST", API_SYSTEM, "poweroff")

--- a/test_shutdown.py
+++ b/test_shutdown.py
@@ -1,0 +1,23 @@
+import aiohttp
+import asyncio
+from pyhifiberry import audiocontrol2
+
+async def main():
+    try:
+        async with aiohttp.ClientSession() as session:
+            api = audiocontrol2.Audiocontrol2(session, host="hifiberry", authtoken="hifiberry")
+
+            status =  await api.status()
+            print(status)
+           
+            print(await api.info())
+            await api.poweroff()
+            return
+ 
+    except audiocontrol2.Audiocontrol2Exception as err:
+        print(err) 
+        if err.original:
+            print("Original Exception: ", err.original)       
+
+if __name__ == "__main__":
+    asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
Hi @dgomes,

I would like to add the poweroff feature to the [homeassistant integration](https://github.com/willholdoway/hifiberry).
The [hifiberry audiocontrol2](https://github.com/hifiberry/audiocontrol2) already merged a PR with a little fix so that the call returns before poweroff is triggered.

Thanks