### PR TITLE
add socketio api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/settings.json
+Pipfile
+Pipfile.lock
+pytest.ini

--- a/pyhifiberry/audiocontrol2sio.py
+++ b/pyhifiberry/audiocontrol2sio.py
@@ -1,0 +1,114 @@
+"""Socketio based API to Hifiberry OS - audiocontrol2"""
+import logging
+
+from socketio import AsyncClient, AsyncClientNamespace
+
+from .consts import DEFAULT_HOST, DEFAULT_PORT
+
+_LOGGER = logging.getLogger(__name__)
+
+class Audiocontrol2SIO:
+
+    def __init__(self, sio) -> None:
+        self.connected = False
+        self.metadata = Metadata(sio)
+        self.player = Player(sio)
+        self.volume = Volume(sio)
+        self._sio = sio
+
+    @classmethod
+    async def connect(cls, host=DEFAULT_HOST, port=DEFAULT_PORT, wait_timeout=10):
+        _LOGGER.info("TRYING TO CONNECT")
+        sio = AsyncClient()
+        audiocontrol = Audiocontrol2SIO(sio)
+        sio.register_namespace(audiocontrol.metadata)
+        sio.register_namespace(audiocontrol.player)
+        sio.register_namespace(audiocontrol.volume)
+
+        @sio.event
+        async def connect():
+            _LOGGER.info("audiocontroller connected to host %s", host)
+            audiocontrol.connected = True
+
+        @sio.event
+        async def disconnect():
+            _LOGGER.info("audiocontroller disconnected from host %s", host)
+            audiocontrol.connected = False
+
+        await sio.connect(f'http://{host}:{port}', wait_timeout=wait_timeout)
+        return audiocontrol
+
+    async def disconnect(self):
+        await self._sio.disconnect()
+
+class Player(AsyncClientNamespace):
+
+    def __init__(self, sio):
+        super().__init__(namespace="/player")
+        self.sio = sio
+
+    async def play(self):
+        await self.sio.emit("play", namespace="/player")
+
+    async def pause(self):
+        await self.sio.emit("pause", namespace="/player")
+
+    async def playpause(self):
+        await self.sio.emit("playpause", namespace="/player")
+
+    async def stop(self):
+        await self.sio.emit("stop", namespace="/player")
+
+    async def next(self):
+        await self.sio.emit("next", namespace="/player")
+
+    async def previous(self):
+        await self.sio.emit("previous", namespace="/player")
+
+    async def get_status(self):
+        return await self.sio.call("status", namespace="/player")
+
+    async def playing(self):
+        return await self.sio.call("playing", namespace="/player")
+
+class Metadata(AsyncClientNamespace):
+
+    def __init__(self, sio):
+        super().__init__(namespace="/metadata")
+        self.sio = sio
+        self.callbacks = set()
+
+    def add_callback(self, callback):
+        self.callbacks.add(callback)
+
+    async def on_update(self, data):
+        _LOGGER.info("update")
+        for callback in self.callbacks:
+            callback(data)
+
+    def set_metadata(self, metadata):
+        self.metadata = metadata
+
+    async def get_metadata(self):
+        return await self.sio.call("get", namespace="/metadata")
+
+class Volume(AsyncClientNamespace):
+
+    def __init__(self, sio):
+        super().__init__(namespace="/volume")
+        self.sio = sio
+        self.callbacks = set()
+
+    def add_callback(self, callback):
+        self.callbacks.add(callback)
+
+    async def on_update(self, data):
+        _LOGGER.info("update")
+        for callback in self.callbacks:
+            callback(data)
+
+    async def get(self):
+        return await self.sio.call("get", namespace="/volume")
+
+    async def set(self, volume):
+        return await self.sio.call("set", volume, namespace="/volume")

--- a/pyhifiberry/audiocontrol2sio.py
+++ b/pyhifiberry/audiocontrol2sio.py
@@ -69,6 +69,9 @@ class Player(AsyncClientNamespace):
         return await self.sio.call("status", namespace="/player")
 
     async def playing(self):
+        """The audiocontrol2 api has an undocumented endpoint /api/player/playing returning 
+        whether or not any player is active.
+        """
         return await self.sio.call("playing", namespace="/player")
 
 class Metadata(AsyncClientNamespace):

--- a/pyhifiberry/audiocontrol2sio.py
+++ b/pyhifiberry/audiocontrol2sio.py
@@ -77,20 +77,32 @@ class Metadata(AsyncClientNamespace):
         super().__init__(namespace="/metadata")
         self.sio = sio
         self.callbacks = set()
+        self.title = None
+        self.artist = None
+        self.albumTitle = None
+        self.albumArtist = None
+        self.tracknumber = None
+        self.artUrl = None
+        self.externalArtUrl = None
+        self.playerName = None
 
     def add_callback(self, callback):
         self.callbacks.add(callback)
 
-    async def on_update(self, data):
-        _LOGGER.info("update")
+    async def on_update(self, meta):
+        self._set_metadata(meta)
         for callback in self.callbacks:
-            callback(data)
-
-    def set_metadata(self, metadata):
-        self.metadata = metadata
+            callback(meta)
 
     async def get_metadata(self):
-        return await self.sio.call("get", namespace="/metadata")
+        meta = await self.sio.call("get", namespace="/metadata")
+        self._set_metadata(meta)
+        return meta
+
+    def _set_metadata(self, meta):
+        for field, value in meta.items():
+            setattr(self, field, value)
+
 
 class Volume(AsyncClientNamespace):
 
@@ -103,7 +115,6 @@ class Volume(AsyncClientNamespace):
         self.callbacks.add(callback)
 
     async def on_update(self, data):
-        _LOGGER.info("update")
         for callback in self.callbacks:
             callback(data)
 

--- a/pyhifiberry/audiocontrol2sio.py
+++ b/pyhifiberry/audiocontrol2sio.py
@@ -27,12 +27,12 @@ class Audiocontrol2SIO:
 
         @sio.event
         async def connect():
-            _LOGGER.info("audiocontroller connected to host %s", host)
+            _LOGGER.debug("audiocontroller connected to host %s", host)
             audiocontrol.connected = True
 
         @sio.event
         async def disconnect():
-            _LOGGER.info("audiocontroller disconnected from host %s", host)
+            _LOGGER.debug("audiocontroller disconnected from host %s", host)
             audiocontrol.connected = False
 
         await sio.connect(f'http://{host}:{port}', wait_timeout=wait_timeout)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     platforms='any',
     install_requires=[
         'aiohttp',
+        'python-socketio[asyncio_client]'
       ],
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/test/test_audiocontrol2sio.py
+++ b/test/test_audiocontrol2sio.py
@@ -9,6 +9,8 @@ from pyhifiberry.audiocontrol2sio import Audiocontrol2SIO
 @pytest.fixture
 async def audiocontrol() -> Audiocontrol2SIO:
     api = await Audiocontrol2SIO.connect('localhost', 8080)
+    while not api.connected:
+        await asyncio.sleep(0.1)
     yield api
     await api.disconnect()
 
@@ -49,19 +51,25 @@ async def test_player_pause_play(audiocontrol: Audiocontrol2SIO):
 async def test_volume(audiocontrol: Audiocontrol2SIO):
     cb = VolumeCallback()
     audiocontrol.volume.add_callback(cb)
-    volume = await audiocontrol.volume.get()
-    new_volume = (volume['percent'] + 1) if volume['percent'] < 99 else 0
-    await audiocontrol.volume.set({'percent': new_volume})
+    while audiocontrol.volume.percent is None:          ### percent is set on connect so we migth have to wait here
+        await asyncio.sleep(0.1)
+    new_volume = audiocontrol.volume.percent + 1 if audiocontrol.volume.percent < 99 else 0
+    foo = await audiocontrol.volume.set(new_volume)
     await asyncio.sleep(1)
     
     assert cb.volume['percent'] == new_volume
 
 @pytest.mark.asyncio
-async def test_set_volume_error(audiocontrol: Audiocontrol2SIO):
-    response = await audiocontrol.volume.set({'percent': 'Hello'})
+async def test_set_volume(audiocontrol: Audiocontrol2SIO):
+    await audiocontrol.volume.set(10)
     
-    assert "error" in response.keys()
+    assert audiocontrol.volume.percent == 10
 
+@pytest.mark.asyncio
+async def test_set_volume_error(audiocontrol: Audiocontrol2SIO):
+    with pytest.raises(Exception):
+        response = await audiocontrol.volume.set('Hello')
+    
 
 class VolumeCallback:
     def __init__(self) -> None:

--- a/test/test_audiocontrol2sio.py
+++ b/test/test_audiocontrol2sio.py
@@ -1,0 +1,80 @@
+import json
+import asyncio
+from typing import Any
+
+import pytest
+from pyhifiberry.audiocontrol2sio import Audiocontrol2SIO, Metadata
+
+
+@pytest.fixture
+async def audiocontrol() -> Audiocontrol2SIO:
+    api = await Audiocontrol2SIO.connect('localhost', 8080)
+    yield api
+    await api.disconnect()
+
+@pytest.mark.asyncio
+async def test_disconnect(audiocontrol: Audiocontrol2SIO):
+    await audiocontrol.disconnect()
+    assert not audiocontrol.connected
+
+@pytest.mark.asyncio
+async def test_get_metadata(audiocontrol: Audiocontrol2SIO):
+    response = await audiocontrol.metadata.get_metadata()
+    assert response.get('title') is not None
+
+@pytest.mark.asyncio
+async def test_metadata_callback(audiocontrol: Audiocontrol2SIO):
+    cb = MetadataCallback()
+    audiocontrol.metadata.add_callback(cb)
+    await audiocontrol.player.next()
+    await asyncio.sleep(1)
+
+    assert cb.metadata
+
+@pytest.mark.asyncio
+async def test_player_status(audiocontrol: Audiocontrol2SIO):
+    status = await audiocontrol.player.get_status()
+    assert 'players' in status.keys()
+
+@pytest.mark.asyncio
+async def test_player_pause_play(audiocontrol: Audiocontrol2SIO):
+    await audiocontrol.player.pause()
+    await asyncio.sleep(1) 
+    assert not await audiocontrol.player.playing()
+    await audiocontrol.player.play()
+    await asyncio.sleep(1)
+    assert await audiocontrol.player.playing()
+
+@pytest.mark.asyncio
+async def test_volume(audiocontrol: Audiocontrol2SIO):
+    cb = VolumeCallback()
+    audiocontrol.volume.add_callback(cb)
+    volume = await audiocontrol.volume.get()
+    new_volume = (volume['percent'] + 1) if volume['percent'] < 99 else 0
+    await audiocontrol.volume.set({'percent': new_volume})
+    await asyncio.sleep(1)
+    
+    assert cb.volume['percent'] == new_volume
+
+@pytest.mark.asyncio
+async def test_set_volume_error(audiocontrol: Audiocontrol2SIO):
+    response = await audiocontrol.volume.set({'percent': 'Hello'})
+    
+    assert "error" in response.keys()
+
+
+class VolumeCallback:
+    def __init__(self) -> None:
+        self.volume = {'percent': 0}
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        self.volume = args[0]
+
+
+class MetadataCallback:
+    def __init__(self) -> None:
+        self.metadata = None
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        self.metadata = args[0]
+

--- a/test/test_audiocontrol2sio.py
+++ b/test/test_audiocontrol2sio.py
@@ -1,4 +1,3 @@
-import json
 import asyncio
 from typing import Any
 

--- a/test/test_audiocontrol2sio.py
+++ b/test/test_audiocontrol2sio.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Any
 
 import pytest
-from pyhifiberry.audiocontrol2sio import Audiocontrol2SIO, Metadata
+from pyhifiberry.audiocontrol2sio import Audiocontrol2SIO
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ async def test_metadata_callback(audiocontrol: Audiocontrol2SIO):
     await audiocontrol.player.next()
     await asyncio.sleep(1)
 
-    assert cb.metadata
+    assert cb.metadata.get('title') == audiocontrol.metadata.title
 
 @pytest.mark.asyncio
 async def test_player_status(audiocontrol: Audiocontrol2SIO):


### PR DESCRIPTION
Hi,
I finally got found the time to finish the implementation for the feature discussed [here](https://github.com/willholdoway/hifiberry/issues/3). 
I also created a PR for the [audiocontrol2](https://github.com/hifiberry/audiocontrol2/pull/22) side. Since it might take some time for the PR to be released you might want to test this implementation against a local audiocontrol2 installation. For the tests to succeed you will need a running player that supports next/previous. I used mpd with a few songs in the playlist. Looking forward to hear what you think about it.