### PR TITLE
Resolve variable name clash

### DIFF
--- a/pyhifiberry/audiocontrol2.py
+++ b/pyhifiberry/audiocontrol2.py
@@ -39,7 +39,7 @@ class Audiocontrol2:
         self.base_url = f"http://{host}:{port}"
         self.authtoken = authtoken
 
-    async def _request(self, method, api_template, endpoint="", json={}):
+    async def _request(self, method, api_template, endpoint="", json_dict={}):
         """Issue API requests."""
 
         headers = {}
@@ -47,11 +47,11 @@ class Audiocontrol2:
             headers = {"Authtoken": self.authtoken}
 
         url = api_template.format(self.base_url, endpoint)
-        LOGGER.debug("request %s %s with %s", method, url, json)
+        LOGGER.debug("request %s %s with %s", method, url, json_dict)
 
         try:
             async with self.websession.request(
-                method, url, headers=headers, json=json, timeout=2
+                method, url, headers=headers, json=json_dict, timeout=2
             ) as res:
                 if res.status != 200:
                     raise Audiocontrol2Exception(f"Couldn't request {url}, status: {res.status}")


### PR DESCRIPTION
The `json` variable in `_request` is no longer overwriting the `json` module, which
results in an error while handling exceptions.

Problem is visible as:
```
File "pyhifiberry/audiocontrol2.py", line 65, in _request
except json.decoder.JSONDecodeError as err:
AttributeError: 'dict' object has no attribute 'decoder'
```